### PR TITLE
Support ESP-IDF 3.3

### DIFF
--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -47,7 +47,7 @@ HASH_CMD="shasum -a 256"
 # Install dependencies
 # --------------------------------------------------------------------------------
 
-ESP_IDF_VERSION=v3.0.4
+ESP_IDF_VERSION=release/v3.3
 if test "${TRAVIS_OS_NAME}" = "linux"; then
     XTENSA_TOOL_CHAIN_URL=https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz
     XTENSA_TOOL_CHAIN_HASH=3fe96c151d46c1d4e5edc6ed690851b8e53634041114bad04729bc16b0445156
@@ -96,6 +96,11 @@ git -C ${TRAVIS_BUILD_DIR} submodule init || exit 1
 git -C ${TRAVIS_BUILD_DIR} submodule update || exit 1
 
 set +x
+
+# --------------------------------------------------------------------------------
+# Prepare python
+# --------------------------------------------------------------------------------
+python -m pip install --user -r ${TRAVIS_BUILD_DIR}/esp-idf/requirements.txt
 
 
 # --------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,12 @@ COMPONENTS              := app_trace \
                            console \
                            cxx \
                            driver \
+                           efuse \
                            esp32 \
                            esp_adc_cal \
+                           esp_event \
+                           esp_ringbuf \
+                           espcoredump \
                            esptool_py \
                            ethernet \
                            expat \
@@ -73,6 +77,7 @@ COMPONENTS              := app_trace \
                            pthread \
                            QRCode \
                            sdmmc \
+                           smartconfig_ack \
                            soc \
                            spidriver \
                            spi_flash \

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -17,8 +17,11 @@ CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
 CONFIG_APP_OFFSET=0x10000
 
 # Bump the stack size of the Weave task to accommodate extra stack useage due to
-# debugging.
-CONFIG_WEAVE_TASK_STACK_SIZE=5120
+# debugging. When using ESP-IDF3.3, there exists a callpath that when reached
+# DataManagement_Current::PrettyPrintWDM, ~4400B stack space is used (default
+# stack size is 4608B). And then vsnprintf called by PerttyPrintWDM will cost
+# another 1KB, a 5120B stack space in previous versions will overflow.
+CONFIG_WEAVE_TASK_STACK_SIZE=6144
 
 # Default to 921600 baud when flashing and monitoring device
 CONFIG_ESPTOOLPY_BAUD_921600B=y
@@ -46,3 +49,6 @@ CONFIG_LOG_PROVISIONING_HASH=y
 # purposes.
 CONFIG_DEFAULT_INCOMING_CONNECTION_IDLE_TIMEOUT=0
 
+# According to partitions.csv, we need 4MB or larger flash
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
+CONFIG_ESPTOOLPY_FLASHSIZE="4MB"


### PR DESCRIPTION
- A few more components is required for esp-idf 3.3
- Need 8192B stack to avoid stackoverflow
- The partition table requires 2.1M flash
- lwip updated

Ths CI might not pass since it requires https://github.com/openweave/openweave-core/pull/567 